### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://tiagocosta-training.visualstudio.com/3b779383-dce3-495e-9e2f-7a5b85b0aa0b/37e68c01-6b9f-4e97-a6be-35888281d188/_apis/work/boardbadge/df550dc3-a644-4c89-b686-12ddb1c3cc12)](https://tiagocosta-training.visualstudio.com/3b779383-dce3-495e-9e2f-7a5b85b0aa0b/_boards/board/t/37e68c01-6b9f-4e97-a6be-35888281d188/Microsoft.RequirementCategory)
 # azure-boards-demo
 Repo to demo Azure Boards Integration


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3346](https://tiagocosta-training.visualstudio.com/3b779383-dce3-495e-9e2f-7a5b85b0aa0b/_workitems/edit/3346). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.